### PR TITLE
Fix dangerous PATH definition in cron

### DIFF
--- a/manifests/node/factsource/yaml.pp
+++ b/manifests/node/factsource/yaml.pp
@@ -11,14 +11,14 @@ class mcollective::node::factsource::yaml {
     content => template('mcollective/refresh-mcollective-metadata.erb'),
   } ->
   cron { 'refresh-mcollective-metadata':
-    environment => "PATH=/opt/puppet/bin:${::path}",
+    environment => 'PATH=/opt/puppet/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin',
     command     => "${mcollective::params::libdir}/refresh-mcollective-metadata",
     user        => 'root',
     minute      => [ '0', '15', '30', '45' ],
   }
 
   exec { 'create-mcollective-metadata':
-    path    => "/opt/puppet/bin:${::path}",
+    path    => '/opt/puppet/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin',
     command => "${mcollective::params::libdir}/refresh-mcollective-metadata",
     creates => $yaml_fact_path_real,
     require => File["${mcollective::params::libdir}/refresh-mcollective-metadata"],


### PR DESCRIPTION
This PATH definition based on current ::path fact breaks when puppet
is run in the same crontab without its own PATH definition. Each puppet
run adds one `/opt/puppet/bin` to the variable.

The `::path` fact should probably never be used in a Puppet recipe as it
can change depending on the environment in which puppet is run.