### PR TITLE
Add initial support for Puppet 4 AIO based installations

### DIFF
--- a/manifests/client/discovery/puppetdb.pp
+++ b/manifests/client/discovery/puppetdb.pp
@@ -5,6 +5,8 @@ class mcollective::client::discovery::puppetdb (
   $ssl_cert = $mcollective::client::broker_ssl_cert,
   $ssl_ca   = $mcollective::client::broker_ssl_ca,
 ) {
+  $cfgdir = $mcollective::params::cfgdir
+  validate_absolute_path($cfgdir)
 
   if $use_ssl {
     $content = "
@@ -26,7 +28,7 @@ plugin.discovery.puppetdb.port = 8080
   concat::fragment { 'mcollective client.cfg puppetdb discovery':
     ensure  => 'present',
     order   => '99',
-    target  => '/etc/mcollective/client.cfg',
+    target  => "${cfgdir}/client.cfg",
     content => $content,
   }
 

--- a/manifests/client/files.pp
+++ b/manifests/client/files.pp
@@ -6,7 +6,9 @@ class mcollective::client::files {
 
   # For the templates
   $libdir = $mcollective::params::libdir
+  $cfgdir = $mcollective::params::cfgdir
   validate_absolute_path($libdir)
+  validate_absolute_path($cfgdir)
 
   $security_provider = $mcollective::client::security_provider
   validate_string($security_provider)
@@ -70,7 +72,7 @@ fi
     }
   }
 
-  concat { '/etc/mcollective/client.cfg':
+  concat { "${cfgdir}/client.cfg":
     mode  => '0644',
     owner => 'root',
     group => 'root',
@@ -79,7 +81,7 @@ fi
   concat::fragment { 'mcollective client.cfg base':
     ensure  => present,
     order   => '00',
-    target  => '/etc/mcollective/client.cfg',
+    target  => "${cfgdir}/client.cfg",
     content => template('mcollective/client.cfg.erb'),
   }
 

--- a/manifests/directories.pp
+++ b/manifests/directories.pp
@@ -2,7 +2,11 @@
 #
 # Manages the basic directories for MCollective
 class mcollective::directories {
-  file { ['/etc/mcollective', '/etc/mcollective/ssl']:
+
+  $cfgdir = $mcollective::params::cfgdir
+  validate_absolute_path($cfgdir)
+
+  file { [ "${cfgdir}", "${cfgdir}/ssl" ]:
     ensure => 'directory',
     owner  => 'root',
     group  => 'root',

--- a/manifests/node/factsource/yaml.pp
+++ b/manifests/node/factsource/yaml.pp
@@ -1,6 +1,6 @@
 class mcollective::node::factsource::yaml {
   $excluded_facts      = []
-  $yaml_fact_path_real = '/etc/mcollective/facts.yaml'
+  $yaml_fact_path_real = "${mcollective::params::cfgdir}/facts.yaml"
 
   # Template uses:
   #   - $yaml_fact_path_real
@@ -11,14 +11,14 @@ class mcollective::node::factsource::yaml {
     content => template('mcollective/refresh-mcollective-metadata.erb'),
   } ->
   cron { 'refresh-mcollective-metadata':
-    environment => 'PATH=/opt/puppet/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin',
+    environment => 'PATH=/opt/puppetlabs/puppet/bin:/opt/puppet/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin',
     command     => "${mcollective::params::libdir}/refresh-mcollective-metadata",
     user        => 'root',
     minute      => [ '0', '15', '30', '45' ],
   }
 
   exec { 'create-mcollective-metadata':
-    path    => '/opt/puppet/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin',
+    path    => '/opt/puppetlabs/puppet/bin:/opt/puppet/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin',
     command => "${mcollective::params::libdir}/refresh-mcollective-metadata",
     creates => $yaml_fact_path_real,
     require => File["${mcollective::params::libdir}/refresh-mcollective-metadata"],

--- a/manifests/node/files.pp
+++ b/manifests/node/files.pp
@@ -19,7 +19,9 @@ class mcollective::node::files {
 
   # Variables for the templates
   $libdir = $mcollective::params::libdir
+  $cfgdir = $mcollective::params::cfgdir
   validate_absolute_path($libdir)
+  validate_absolute_path($cfgdir)
   $daemonize = 1
 
   $identity = $mcollective::node::identity
@@ -56,7 +58,7 @@ class mcollective::node::files {
     }
   }
 
-  file { '/etc/mcollective/server.cfg':
+  file { "${cfgdir}/server.cfg":
     ensure  => file,
     mode    => '0640',
     owner   => 'root',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -3,18 +3,23 @@ class mcollective::params {
   $broker_user = 'guest'
   $broker_password = 'guest'
   $broker_ssl = true
-  $broker_ssl_cert = '/etc/mcollective/ssl/mco-client.crt'
-  $broker_ssl_key = '/etc/mcollective/ssl/mco-client.key'
-  $broker_ssl_ca = '/etc/mcollective/ssl/ca.pem'
+  if versioncmp($::puppetversion, '4.0.0') >= 0 {
+    $cfgdir = '/etc/puppetlabs/mcollective'
+  } else {
+    $cfgdir = '/etc/mcollective'
+  }
+  $broker_ssl_cert = "${cfgdir}/ssl/mco-client.crt"
+  $broker_ssl_key = "${cfgdir}/ssl/mco-client.key"
+  $broker_ssl_ca = "${cfgdir}/ssl/ca.pem"
   # lint:ignore:empty_string_assignment
   $security_secret = ''
   # lint:endignore
-  $security_ssl_server_private = '/etc/mcollective/ssl/server-private.pem'
-  $security_ssl_server_public = '/etc/mcollective/ssl/server-public.pem'
+  $security_ssl_server_private = "${cfgdir}/ssl/server-private.pem"
+  $security_ssl_server_public = "${cfgdir}/ssl/server-public.pem"
   $security_ssl_client_private = false
   $security_ssl_client_public = false
-  $security_aes_server_private = '/etc/mcollective/ssl/server-private.pem'
-  $security_aes_server_public = '/etc/mcollective/ssl/server-public.pem'
+  $security_aes_server_private = "${cfgdir}/ssl/server-private.pem"
+  $security_aes_server_public = "${cfgdir}/ssl/server-public.pem"
   $security_aes_client_private = false
   $security_aes_client_public = false
   $security_aes_send_pubkey = 0
@@ -26,8 +31,8 @@ class mcollective::params {
   $rpcauthprovider = 'action_policy'
   $rpcauth_allow_unconfigured = 0
   $rpcauth_enable_default = 1
-  $cert_dir = '/etc/mcollective/ssl/clients'
-  $policies_dir = '/etc/mcollective/policies'
+  $cert_dir = "${cfgdir}/ssl/clients"
+  $policies_dir = "${cfgdir}/policies"
   $use_node = true
   $use_client = false
   $direct_addressing = 0
@@ -52,7 +57,11 @@ class mcollective::params {
         $server_require = Package['rubygems', 'rubygem-stomp']
       }
       $plugin_require = Package['rubygems', 'rubygem-stomp']
-      $libdir = '/usr/libexec/mcollective'
+      if versioncmp($::puppetversion, '4.0.0') >= 0 {
+        $libdir = '/opt/puppetlabs/puppet/lib/ruby/vendor_ruby'
+      } else {
+        $libdir = '/usr/libexec/mcollective'
+      }
     }
 
     default: {

--- a/templates/client.cfg.erb
+++ b/templates/client.cfg.erb
@@ -47,6 +47,6 @@ plugin.<%= scope.lookupvar('mcollective::client::connector') %>.pool.1.ssl.ca = 
 
 # Facts
 factsource = yaml
-plugin.yaml = /etc/mcollective/facts.yaml
+plugin.yaml = <%= @cfgdir %>/facts.yaml
 
 default_discovery_method = <%= scope.lookupvar('mcollective::client::default_discovery_method') %>

--- a/templates/server.cfg.erb
+++ b/templates/server.cfg.erb
@@ -56,7 +56,7 @@ plugin.puppetca.cadir = <%= @puppetca_cadir %>
 
 # Facts
 factsource = yaml
-plugin.yaml = /etc/mcollective/facts.yaml
+plugin.yaml = <%= @cfgdir %>/facts.yaml
 
 classesfile = /var/lib/puppet/state/classes.txt
 


### PR DESCRIPTION
Add initial support for Puppet 4 AIO based installations.
Specifically:
- add "/opt/puppetlabs/puppet/bin" to $PATH
- add new variable $cfgdir and set it based on puppetversion to "/etc/puppetlabs/mcollective" or "/etc/mcollective"
- replace all occurrences of "/etc/mcollective" with $cfgdir
- set libdir based on puppetversion to "/opt/puppetlabs/puppet/lib/ruby/vendor_ruby" or "/usr/libexec/mcollective"